### PR TITLE
throw visible error when agent install fails

### DIFF
--- a/src/xtfsDscAgent/xTfsDscAgent.psd1
+++ b/src/xtfsDscAgent/xTfsDscAgent.psd1
@@ -12,7 +12,7 @@
     RootModule = 'xTfsDscAgent.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.0.70'
+    ModuleVersion = '1.0.73'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -30,7 +30,7 @@
     Copyright = '(c) 2017 Paul. Alle Rechte vorbehalten.'
     
     # Description of the functionality provided by this module
-    Description = 'xTfsDscAgent is a Powershell Desire-State Module to install an configure a TFS / VSTS Build Agents.'
+    Description = 'DSC Resource for TFS Agent'
     
     # Minimum version of the Windows PowerShell engine required by this module
     # PowerShellVersion = ''
@@ -122,6 +122,4 @@
     # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
     # DefaultCommandPrefix = ''
     
-    }
-    
-    
+    }    

--- a/src/xtfsDscAgent/xTfsDscAgent.psm1
+++ b/src/xtfsDscAgent/xTfsDscAgent.psm1
@@ -202,7 +202,7 @@ class xTfsDscAgent {
         $bytes = [System.Text.Encoding]::Unicode.GetBytes($fullString)
         #$encodedCommand = [Convert]::ToBase64String($bytes)
         Write-Verbose ("Start installation: " + (Get-Date));
-        cmd /c "$($this.AgentFolder)\config.cmd $configureString"
+        cmd /c "$($this.AgentFolder)\config.cmd $configureString";
         Write-Verbose ("Installation completed: $(Get-Date)");
     }
     [void] startAgent() {        


### PR DESCRIPTION
I have made some minor improvements to the resource:

1. Obfuscated password from Verbose output (line 200)
2. call agent install via CMD which will can throw visible error when start-dscconfiguration is run
